### PR TITLE
Update helper.js and resolve status errors

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -167,7 +167,7 @@ async function callApi(endpoint, accessToken) {
         }
         return response.data;
     } catch (error) {
-        if (error.response.status == 403) {
+        if (error.response && error.response.status == 403) {
             debugLogger(`403 error`, error.response?.data, error)
             global.forbiddenErrors.push(`${error?.response?.status} ${error?.response?.statusText} for '${error?.response?.config?.url}'`)
             // process.exit()


### PR DESCRIPTION
## Purpose:
This adds a null/undefined check for error.response before trying to access its status property. Without this check, when error.response is null or undefined, the code would throw a "Cannot read property 'status' of null/undefined" error.

#### The original code:
```javascript
if (error.response.status == 403) {
```
#### The updated code:
```javascript
if (error.response && error.response.status == 403) {
```

## Why this is important:
In JavaScript, network errors or other types of errors might not always have a response object, so this defensive programming prevents the application from crashing when trying to handle errors. This has caused issues for some users, as referenced in #16 when the error response is likely returning without a response.